### PR TITLE
Add redundancy, remove `https` option, add `onlyHttps` option…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,4 @@
-# Has IPv6 support according to https://docs.travis-ci.com/user/reference/overview/
-os: linux
-arch: arm64
-dist: trusty
 language: node_js
 node_js:
   - '12'
   - '10'
-before_script:
-  # Add an IPv6 config
-  # See: https://github.com/travis-ci/travis-ci/issues/8361
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-      sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
-    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+# Has ipv6 support according to https://docs.travis-ci.com/user/reference/overview/
+os: linux
+arch: arm64
+dist: bionic
+
 language: node_js
 node_js:
   - '12'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 # Has ipv6 support according to https://docs.travis-ci.com/user/reference/overview/
+sudo: required
 os: linux
 arch: arm64
-dist: bionic
+dist: trusty
+before_script:
+  # Add an IPv6 config - see the corresponding Travis issue
+  # https://github.com/travis-ci/travis-ci/issues/8361
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+      sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
+    fi
 
 language: node_js
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 # Has ipv6 support according to https://docs.travis-ci.com/user/reference/overview/
-sudo: required
 os: linux
 arch: arm64
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
-# Has ipv6 support according to https://docs.travis-ci.com/user/reference/overview/
+# Has IPv6 support according to https://docs.travis-ci.com/user/reference/overview/
 os: linux
 arch: arm64
 dist: trusty
-before_script:
-  # Add an IPv6 config - see the corresponding Travis issue
-  # https://github.com/travis-ci/travis-ci/issues/8361
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-      sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
-    fi
-
 language: node_js
 node_js:
   - '12'
   - '10'
+before_script:
+  # Add an IPv6 config
+  # See: https://github.com/travis-ci/travis-ci/issues/8361
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+      sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
+    fi

--- a/browser.js
+++ b/browser.js
@@ -42,7 +42,7 @@ const sendXhr = async (url, options, version) => {
 
 const queryHttps = async (version, options) => {
 	let ip;
-	const _urls = [].concat.apply(urls[version], options.urls || []);
+	const _urls = [].concat.apply(urls[version], options.fallbackUrls || []);
 	for (const url of _urls) {
 		try {
 			// eslint-disable-next-line no-await-in-loop

--- a/browser.js
+++ b/browser.js
@@ -8,11 +8,11 @@ const defaults = {
 const urls = {
 	v4: [
 		'https://ipv4.icanhazip.com/',
-		'https://api.ipify.org'
+		'https://api.ipify.org/'
 	],
 	v6: [
 		'https://ipv6.icanhazip.com/',
-		'https://api6.ipify.org'
+		'https://api6.ipify.org/'
 	]
 };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,13 +8,6 @@ declare namespace publicIp {
 		readonly https?: boolean;
 
 		/**
-		Use or disable a DNS check using opendns or google dns services.
-
-		@default null
-		*/
-		readonly dns?: boolean;
-
-		/**
 		The time in milliseconds until a request is considered timed out.
 
 		@default 5000

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ declare namespace publicIp {
 		readonly timeout?: number;
 
 		/**
-		Use a HTTPS check using the [icanhazip.com](https://github.com/major/icanhaz) service instead of the DNS query. [ipify.org](https://www.ipify.org) is used as a fallback if `icanhazip.com` fails. This check is much more secure and tamper-proof, but also a lot slower. **This option is only available in the Node.js version**. Default behaviour is to check aginst DNS before using HTTPS fallback, if set as `true` it will *only* check against HTTPS.
+		In case you want to add your own custom HTTPS endpoints to get public IP from (like [ifconfig.co](https://ifconfig.co), for example), you can set them here. They will only be used if everything else fails. Any service used as fallback *must* return the IP as a plain string.
 
 		@default []
 		 */
@@ -31,7 +31,7 @@ declare const publicIp: {
 	/**
 	Get your public IP address - very fast!
 
-	In Node.js, it queries the DNS records of OpenDNS, Google DNS and HTTPS services to determine your IP address. In browsers, it uses the excellent [icanhaz](https://github.com/major/icanhaz) service through HTTPS.
+	In Node.js, it queries the DNS records of OpenDNS, Google DNS and HTTPS services to determine your IP address. In browsers, it uses the excellent [icanhaz](https://github.com/major/icanhaz) and [ipify](https://ipify.org) services through HTTPS.
 
 	@returns Your public IPv4 address. A `.cancel()` method is available on the promise, which can be used to cancel the request.
 	@throws On error or timeout.
@@ -51,7 +51,7 @@ declare const publicIp: {
 	/**
 	Get your public IP address - very fast!
 
-	In Node.js, it queries the DNS records of OpenDNS, Google DNS and HTTPS services to determine your IP address. In browsers, it uses the excellent [icanhaz](https://github.com/major/icanhaz) service through HTTPS.
+	In Node.js, it queries the DNS records of OpenDNS, Google DNS and HTTPS services to determine your IP address. In browsers, it uses the excellent [icanhaz](https://github.com/major/icanhaz) and [ipify](https://ipify.org) services through HTTPS.
 
 	@returns Your public IPv6 address. A `.cancel()` method is available on the promise, which can be used to cancel the request.
 	@throws On error or timeout.

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ declare namespace publicIp {
 		/**
 		Use a HTTPS check using the [icanhazip.com](https://github.com/major/icanhaz) service instead of the DNS query. [ipify.org](https://www.ipify.org) is used as a fallback if `icanhazip.com` fails. This check is much more secure and tamper-proof, but also a lot slower. **This option is only available in the Node.js version**. Default behaviour is to check aginst DNS before using HTTPS fallback, if set as `true` it will *only* check against HTTPS.
 
-		@default null
+		@default false
 		*/
 		readonly onlyHttps?: boolean;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,11 @@
 declare namespace publicIp {
 	interface Options {
 		/**
-		Use or disable a HTTPS check using the [icanhazip.com](https://github.com/major/icanhaz) service instead of the DNS query. This check is much more secure and tamper-proof, but also a lot slower. **This option is only available in the Node.js version**.
+		Use a HTTPS check using the [icanhazip.com](https://github.com/major/icanhaz) service instead of the DNS query. [ipify.org](https://www.ipify.org) is used as a fallback if `icanhazip.com` fails. This check is much more secure and tamper-proof, but also a lot slower. **This option is only available in the Node.js version**. Default behaviour is to check aginst DNS before using HTTPS fallback, if set as `true` it will *only* check against HTTPS.
 
 		@default null
 		*/
-		readonly https?: boolean;
+		readonly onlyHttps?: boolean;
 
 		/**
 		The time in milliseconds until a request is considered timed out.
@@ -13,6 +13,13 @@ declare namespace publicIp {
 		@default 5000
 		*/
 		readonly timeout?: number;
+
+		/**
+		Use a HTTPS check using the [icanhazip.com](https://github.com/major/icanhaz) service instead of the DNS query. [ipify.org](https://www.ipify.org) is used as a fallback if `icanhazip.com` fails. This check is much more secure and tamper-proof, but also a lot slower. **This option is only available in the Node.js version**. Default behaviour is to check aginst DNS before using HTTPS fallback, if set as `true` it will *only* check against HTTPS.
+
+		@default []
+		 */
+		readonly fallbackUrls?: string[];
 	}
 
 	type CancelablePromise<T> = Promise<T> & {
@@ -24,7 +31,7 @@ declare const publicIp: {
 	/**
 	Get your public IP address - very fast!
 
-	In Node.js, it queries the DNS records of OpenDNS which has an entry with your IP address. In browsers, it uses the excellent [icanhaz](https://github.com/major/icanhaz) service through HTTPS.
+	In Node.js, it queries the DNS records of OpenDNS, Google DNS and HTTPS services to determine your IP address. In browsers, it uses the excellent [icanhaz](https://github.com/major/icanhaz) service through HTTPS.
 
 	@returns Your public IPv4 address. A `.cancel()` method is available on the promise, which can be used to cancel the request.
 	@throws On error or timeout.
@@ -44,7 +51,7 @@ declare const publicIp: {
 	/**
 	Get your public IP address - very fast!
 
-	In Node.js, it queries the DNS records of OpenDNS which has an entry with your IP address. In browsers, it uses the excellent [icanhaz](https://github.com/major/icanhaz) service through HTTPS.
+	In Node.js, it queries the DNS records of OpenDNS, Google DNS and HTTPS services to determine your IP address. In browsers, it uses the excellent [icanhaz](https://github.com/major/icanhaz) service through HTTPS.
 
 	@returns Your public IPv6 address. A `.cancel()` method is available on the promise, which can be used to cancel the request.
 	@throws On error or timeout.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,18 @@
 declare namespace publicIp {
 	interface Options {
 		/**
-		Use a HTTPS check using the [icanhazip.com](https://github.com/major/icanhaz) service instead of the DNS query. This check is much more secure and tamper-proof, but also a lot slower. **This option is only available in the Node.js version**.
+		Use or disable a HTTPS check using the [icanhazip.com](https://github.com/major/icanhaz) service instead of the DNS query. This check is much more secure and tamper-proof, but also a lot slower. **This option is only available in the Node.js version**.
 
-		@default false
+		@default null
 		*/
 		readonly https?: boolean;
+
+		/**
+		Use or disable a DNS check using opendns or google dns services.
+
+		@default null
+		*/
+		readonly dns?: boolean;
 
 		/**
 		The time in milliseconds until a request is considered timed out.

--- a/index.js
+++ b/index.js
@@ -11,34 +11,44 @@ const defaults = {
 
 const dnsServers = [
 	{
-		servers: [
-			'resolver1.opendns.com',
-			'resolver2.opendns.com',
-			'resolver3.opendns.com',
-			'resolver4.opendns.com'
-		],
 		v4: {
+			servers: [
+				'208.67.222.222',
+				'208.67.220.220',
+				'208.67.222.220',
+				'208.67.220.222'
+			],
 			name: 'myip.opendns.com',
 			type: 'A'
 		},
 		v6: {
+			servers: [
+				'2620:0:ccc::2',
+				'2620:0:ccd::2'
+			],
 			name: 'myip.opendns.com',
 			type: 'AAAA'
 		}
 	},
 	{
-		servers: [
-			'ns1.google.com',
-			'ns2.google.com',
-			'ns3.google.com',
-			'ns4.google.com'
-		],
 		v4: {
+			servers: [
+				'216.239.32.10',
+				'216.239.34.10',
+				'216.239.36.10',
+				'216.239.38.10'
+			],
 			name: 'o-o.myaddr.l.google.com',
 			type: 'TXT',
 			clean: ip => ip.replace(/"/g, '')
 		},
 		v6: {
+			servers: [
+				'2001:4860:4802:32::a',
+				'2001:4860:4802:34::a',
+				'2001:4860:4802:36::a',
+				'2001:4860:4802:38::a'
+			],
 			name: 'o-o.myaddr.l.google.com',
 			type: 'TXT',
 			clean: ip => ip.replace(/"/g, '')
@@ -48,9 +58,8 @@ const dnsServers = [
 
 const type = {
 	v4: {
-		dnsServers: dnsServers.map(({servers, v4}) => ({
-			servers,
-			question: v4
+		dnsServers: dnsServers.map(({v4: {servers, ...question}}) => ({
+			servers, question
 		})),
 		httpsUrls: [
 			'https://ipv4.icanhazip.com/',
@@ -58,9 +67,8 @@ const type = {
 		]
 	},
 	v6: {
-		dnsServers: dnsServers.map(({servers, v6}) => ({
-			servers,
-			question: v6
+		dnsServers: dnsServers.map(({v6: {servers, ...question}}) => ({
+			servers, question
 		})),
 		httpsUrls: [
 			'https://ipv6.icanhazip.com/',
@@ -103,6 +111,7 @@ const queryDns = (version, options) => {
 					const ip = clean ? clean(response) : response;
 
 					if (ip && isIp[version](ip)) {
+						socket.destroy();
 						return ip;
 					}
 				} catch (_) {}
@@ -163,7 +172,9 @@ const queryHttps = (version, options) => {
 		}
 	})();
 
-	promise.cancel = cancel;
+	promise.cancel = function () {
+		return cancel.apply(this);
+	};
 
 	return promise;
 };

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ const type = {
 			servers, question
 		})),
 		httpsUrls: [
-			'https://ipv4.icanhazip.com/',
+			'https://icanhazip.com/',
 			'https://api.ipify.org/'
 		]
 	},
@@ -72,7 +72,7 @@ const type = {
 			servers, question
 		})),
 		httpsUrls: [
-			'https://ipv6.icanhazip.com/',
+			'https://icanhazip.com/',
 			'https://api6.ipify.org/'
 		]
 	}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,11 +4,13 @@ import publicIp = require('.');
 const options: publicIp.Options = {};
 
 expectType<publicIp.CancelablePromise<string>>(publicIp.v4());
-expectType<publicIp.CancelablePromise<string>>(publicIp.v4({https: false}));
+expectType<publicIp.CancelablePromise<string>>(publicIp.v4({onlyHttps: true}));
 expectType<publicIp.CancelablePromise<string>>(publicIp.v4({timeout: 10}));
+expectType<publicIp.CancelablePromise<string>>(publicIp.v4({fallbackUrls: ['https://ifconfig.io']}));
 publicIp.v4().cancel();
 
 expectType<publicIp.CancelablePromise<string>>(publicIp.v6());
-expectType<publicIp.CancelablePromise<string>>(publicIp.v6({https: false}));
+expectType<publicIp.CancelablePromise<string>>(publicIp.v6({onlyHttps: true}));
 expectType<publicIp.CancelablePromise<string>>(publicIp.v6({timeout: 10}));
+expectType<publicIp.CancelablePromise<string>>(publicIp.v6({fallbackUrls: ['https://ifconfig.io']}));
 publicIp.v6().cancel();

--- a/mocks/dns-socket.js
+++ b/mocks/dns-socket.js
@@ -1,0 +1,33 @@
+const sinon = require('sinon');
+const dnsSocket = require('dns-socket');
+
+let ignoreRegExp;
+let ignored = [];
+let called = 0;
+
+const original = dnsSocket.prototype.query;
+
+sinon.stub(dnsSocket.prototype, 'query').callsFake(function (...args) {
+	called++;
+	const host = args.slice(-2, -1)[0];
+	if (ignoreRegExp && ignoreRegExp.test(host)) {
+		ignored.push(host);
+		throw new Error('Ignored by mock');
+	}
+
+	return original.bind(this)(...args);
+});
+
+exports.ignore = _ignoreRegExp => {
+	ignoreRegExp = _ignoreRegExp;
+};
+
+exports.ignored = () => ignored;
+
+exports.called = () => called;
+
+exports.restore = () => {
+	ignoreRegExp = undefined;
+	ignored = [];
+	called = 0;
+};

--- a/mocks/dns-socket.js
+++ b/mocks/dns-socket.js
@@ -1,33 +1,3 @@
-const sinon = require('sinon');
-const dnsSocket = require('dns-socket');
+const stub = require('./stub');
 
-let ignoreRegExp;
-let ignored = [];
-let called = 0;
-
-const original = dnsSocket.prototype.query;
-
-sinon.stub(dnsSocket.prototype, 'query').callsFake(function (...args) {
-	called++;
-	const host = args.slice(-2, -1)[0];
-	if (ignoreRegExp && ignoreRegExp.test(host)) {
-		ignored.push(host);
-		throw new Error('Ignored by mock');
-	}
-
-	return original.bind(this)(...args);
-});
-
-exports.ignore = _ignoreRegExp => {
-	ignoreRegExp = _ignoreRegExp;
-};
-
-exports.ignored = () => ignored;
-
-exports.called = () => called;
-
-exports.restore = () => {
-	ignoreRegExp = undefined;
-	ignored = [];
-	called = 0;
-};
+module.exports = stub(require('dns-socket').prototype, 'query', -2);

--- a/mocks/got.js
+++ b/mocks/got.js
@@ -1,0 +1,32 @@
+const sinon = require('sinon');
+const got = require('got');
+
+let ignoreRegExp;
+let ignored = [];
+let called = 0;
+
+const original = got.get;
+
+sinon.stub(got, 'get').callsFake((url, options) => {
+	called++;
+	if (ignoreRegExp && ignoreRegExp.test(url)) {
+		ignored.push(url);
+		throw new Error('Ignored by mock');
+	}
+
+	return original(url, options);
+});
+
+exports.ignore = _ignoreRegExp => {
+	ignoreRegExp = _ignoreRegExp;
+};
+
+exports.ignored = () => ignored;
+
+exports.called = () => called;
+
+exports.restore = () => {
+	ignoreRegExp = undefined;
+	ignored = [];
+	called = 0;
+};

--- a/mocks/got.js
+++ b/mocks/got.js
@@ -1,32 +1,3 @@
-const sinon = require('sinon');
-const got = require('got');
+const stub = require('./stub');
 
-let ignoreRegExp;
-let ignored = [];
-let called = 0;
-
-const original = got.get;
-
-sinon.stub(got, 'get').callsFake((url, options) => {
-	called++;
-	if (ignoreRegExp && ignoreRegExp.test(url)) {
-		ignored.push(url);
-		throw new Error('Ignored by mock');
-	}
-
-	return original(url, options);
-});
-
-exports.ignore = _ignoreRegExp => {
-	ignoreRegExp = _ignoreRegExp;
-};
-
-exports.ignored = () => ignored;
-
-exports.called = () => called;
-
-exports.restore = () => {
-	ignoreRegExp = undefined;
-	ignored = [];
-	called = 0;
-};
+module.exports = stub(require('got'), 'get', 0);

--- a/mocks/stub.js
+++ b/mocks/stub.js
@@ -1,13 +1,13 @@
 const sinon = require('sinon');
 
-module.exports = (objectPath, propertyName, ignoreIndex = null) => {
+module.exports = (objectPath, propertyName, ignoreIndex) => {
 	let ignoreRegExp;
 	let ignored = [];
 
 	const original = objectPath[propertyName];
 
 	function stub(...args) {
-		if (ignoreIndex !== null) {
+		if (ignoreIndex !== undefined) {
 			const ignoreArgument = args.slice(ignoreIndex, ignoreIndex + 1)[0];
 			if (ignoreRegExp && ignoreRegExp.test(ignoreArgument)) {
 				ignored.push(ignoreArgument);

--- a/mocks/stub.js
+++ b/mocks/stub.js
@@ -1,0 +1,35 @@
+const sinon = require('sinon');
+
+module.exports = (objectPath, propertyName, ignoreIndex = null) => {
+	let ignoreRegExp;
+	let ignored = [];
+
+	const original = objectPath[propertyName];
+
+	function stub(...args) {
+		if (ignoreIndex !== null) {
+			const ignoreArgument = args.slice(ignoreIndex, ignoreIndex + 1)[0];
+			if (ignoreRegExp && ignoreRegExp.test(ignoreArgument)) {
+				ignored.push(ignoreArgument);
+				throw new Error('Ignored by mock');
+			}
+		}
+
+		return original.bind(this)(...args);
+	}
+
+	sinon.stub(objectPath, propertyName).callsFake(stub);
+
+	return {
+		ignore: _ignoreRegExp => {
+			ignoreRegExp = _ignoreRegExp;
+		},
+		ignored: () => ignored.length,
+		called: () => objectPath[propertyName].callCount,
+		restore: () => {
+			ignoreRegExp = undefined;
+			ignored = [];
+			objectPath[propertyName].resetHistory();
+		}
+	};
+};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava test.js && tsd"
+		"test": "xo && ava -s test.js && tsd"
 	},
 	"files": [
 		"index.js",
@@ -40,6 +40,7 @@
 	},
 	"devDependencies": {
 		"ava": "^2.2.0",
+		"sinon": "^7.4.1",
 		"tsd": "^0.7.4",
 		"xo": "^0.24.0"
 	},

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
 	"author": {
 		"name": "Sindre Sorhus",
 		"email": "sindresorhus@gmail.com",
-		"url": "sindresorhus.com"
+		"url": "https://sindresorhus.com"
 	},
 	"engines": {
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava -s test.js && tsd"
+		"test": "xo && ava test.js && tsd"
 	},
 	"files": [
 		"index.js",

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Get your public IP address - very fast!
 
-In Node.js, it queries the DNS records of OpenDNS, Google DNS and HTTPS services to determine your IP address. In browsers, it uses the excellent [icanhaz](https://github.com/major/icanhaz) service through HTTPS.
+In Node.js, it queries the DNS records of OpenDNS, Google DNS and HTTPS services to determine your IP address. In browsers, it uses the excellent [icanhaz](https://github.com/major/icanhaz) and [ipify](https://ipify.org) services through HTTPS.
 
 
 ## Install
@@ -50,7 +50,7 @@ Use a HTTPS check using the [icanhazip.com](https://github.com/major/icanhaz) se
 Type: `string[]`<br>
 Default: `[]`
 
-In case you want to add your own custom HTTPS endpoints to get public IP from (like [ifconfig.co](https://ifconfig.co), for example), you can set them here. They will only be used if everything else fails.
+In case you want to add your own custom HTTPS endpoints to get public IP from (like [ifconfig.co](https://ifconfig.co), for example), you can set them here. They will only be used if everything else fails. Any service used as fallback *must* return the IP as a plain string.
 
 Example: `{ fallbackUrls: [ 'https://ifconfig.co/ip' ] }`
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Get your public IP address - very fast!
 
-In Node.js, it queries the DNS records of OpenDNS which has an entry with your IP address. In browsers, it uses the excellent [icanhaz](https://github.com/major/icanhaz) service through HTTPS.
+In Node.js, it queries the DNS records of OpenDNS, Google DNS and HTTPS services to determine your IP address. In browsers, it uses the excellent [icanhaz](https://github.com/major/icanhaz) service through HTTPS.
 
 
 ## Install
@@ -41,9 +41,18 @@ Type: `object`
 ##### https
 
 Type: `boolean`<br>
-Default: `false`
+Default: `null`
 
-Use a HTTPS check using the [icanhazip.com](https://github.com/major/icanhaz) service instead of the DNS query. [ipify.org](https://www.ipify.org) is used as a fallback if `icanhazip.com` fails. This check is much more secure and tamper-proof, but also a lot slower. **This option is only available in the Node.js version**.
+Use a HTTPS check using the [icanhazip.com](https://github.com/major/icanhaz) service instead of the DNS query. [ipify.org](https://www.ipify.org) is used as a fallback if `icanhazip.com` fails. This check is much more secure and tamper-proof, but also a lot slower. **This option is only available in the Node.js version**. Default behaviour is to check aginst DNS before using HTTPS fallback, if set as `true` it will *only* check against HTTPS, and if set to `false` it will *only* check agains DNS.
+
+##### urls
+
+Type: `array`<br>
+Default: `[]`
+
+In case you want to add your own custom HTTPS endpoints to get public IP from (like [ifconfig.co](https://ifconfig.co), por example), you can set them here. They will only be used if everything else fails.
+
+Example: `{ urls: [ 'https://ifconfig.co/ip' ] }`
 
 ##### timeout
 

--- a/readme.md
+++ b/readme.md
@@ -47,10 +47,10 @@ Use a HTTPS check using the [icanhazip.com](https://github.com/major/icanhaz) se
 
 ##### urls
 
-Type: `array`<br>
+Type: `string[]`<br>
 Default: `[]`
 
-In case you want to add your own custom HTTPS endpoints to get public IP from (like [ifconfig.co](https://ifconfig.co), por example), you can set them here. They will only be used if everything else fails.
+In case you want to add your own custom HTTPS endpoints to get public IP from (like [ifconfig.co](https://ifconfig.co), for example), you can set them here. They will only be used if everything else fails.
 
 Example: `{ urls: [ 'https://ifconfig.co/ip' ] }`
 

--- a/readme.md
+++ b/readme.md
@@ -38,21 +38,21 @@ Returns a `Promise<string>` with your public IPv4 or IPv6 address. Rejects on er
 
 Type: `object`
 
-##### https
+##### onlyHttps
 
 Type: `boolean`<br>
-Default: `null`
+Default: `false`
 
-Use a HTTPS check using the [icanhazip.com](https://github.com/major/icanhaz) service instead of the DNS query. [ipify.org](https://www.ipify.org) is used as a fallback if `icanhazip.com` fails. This check is much more secure and tamper-proof, but also a lot slower. **This option is only available in the Node.js version**. Default behaviour is to check aginst DNS before using HTTPS fallback, if set as `true` it will *only* check against HTTPS, and if set to `false` it will *only* check agains DNS.
+Use a HTTPS check using the [icanhazip.com](https://github.com/major/icanhaz) service instead of the DNS query. [ipify.org](https://www.ipify.org) is used as a fallback if `icanhazip.com` fails. This check is much more secure and tamper-proof, but also a lot slower. **This option is only available in the Node.js version**. Default behaviour is to check aginst DNS before using HTTPS fallback, if set as `true` it will *only* check against HTTPS.
 
-##### urls
+##### fallbackUrls
 
 Type: `string[]`<br>
 Default: `[]`
 
 In case you want to add your own custom HTTPS endpoints to get public IP from (like [ifconfig.co](https://ifconfig.co), for example), you can set them here. They will only be used if everything else fails.
 
-Example: `{ urls: [ 'https://ifconfig.co/ip' ] }`
+Example: `{ fallbackUrls: [ 'https://ifconfig.co/ip' ] }`
 
 ##### timeout
 

--- a/test-browser.js
+++ b/test-browser.js
@@ -5,4 +5,9 @@ const publicIp = require('./browser');
 
 (async () => {
 	console.log('IP:', await publicIp.v4());
+	console.log('IP:', await publicIp.v4({
+		urls: [
+			'https://ifconfig.me'
+		]
+	}));
 })();

--- a/test-browser.js
+++ b/test-browser.js
@@ -6,7 +6,7 @@ const publicIp = require('./browser');
 (async () => {
 	console.log('IP:', await publicIp.v4());
 	console.log('IP:', await publicIp.v4({
-		urls: [
+		fallbackUrls: [
 			'https://ifconfig.me'
 		]
 	}));

--- a/test.js
+++ b/test.js
@@ -84,10 +84,12 @@ test('IPv4 HTTPS impossible timeout', async t => {
 	await t.throwsAsync(publicIp.v4({onlyHttps: true, timeout: 1}));
 });
 
-test('IPv6 DNS', async t => {
-	t.true(isIp.v6(await publicIp.v6()));
-});
+if (!process.env.CI) {
+	test('IPv6 DNS', async t => {
+		t.true(isIp.v6(await publicIp.v6()));
+	});
 
-test('IPv6 HTTPS', async t => {
-	t.true(isIp.v6(await publicIp.v6({onlyHttps: true})));
-});
+	test('IPv6 HTTPS', async t => {
+		t.true(isIp.v6(await publicIp.v6({onlyHttps: true})));
+	});
+}

--- a/test.js
+++ b/test.js
@@ -1,78 +1,68 @@
 import test from 'ava';
 import isIp from 'is-ip';
-import {
-	restore as restoreDnsMock,
-	ignore as ignoreDnsHost,
-	ignored as getIgnoredDnsHosts,
-	called as getDnsCalledCount
-} from './mocks/dns-socket';
-import {
-	restore as restoreGotMock,
-	called as getGotCalledCount,
-	ignore as ignoreGotHosts,
-	ignored as getIgnoredGotHosts
-} from './mocks/got';
+import dnsStub from './mocks/dns-socket';
+import gotStub from './mocks/got';
 import publicIp from '.';
 
-test.afterEach(() => {
-	restoreDnsMock();
-	restoreGotMock();
+test.afterEach.always(() => {
+	dnsStub.restore();
+	gotStub.restore();
 });
 
-test('IPv4 DNS - No HTTPS call', async t => {
+test.serial('IPv4 DNS - No HTTPS call', async t => {
 	t.true(isIp.v4(await publicIp.v4()));
-	t.true(getDnsCalledCount() > 0);
-	t.true(getIgnoredDnsHosts().length === 0);
-	t.true(getGotCalledCount() === 0);
+	t.true(dnsStub.called() > 0);
+	t.is(dnsStub.ignored(), 0);
+	t.is(gotStub.called(), 0);
 });
 
-test('IPv4 DNS failure fallbacks to HTTPS', async t => {
-	ignoreDnsHost(/.*/);
+test.serial('IPv4 DNS failure fallbacks to HTTPS', async t => {
+	dnsStub.ignore(/.*/);
 	const ip = await publicIp.v4();
 	t.true(isIp.v4(ip));
-	t.true(getIgnoredDnsHosts().length === 8);
-	t.true(getGotCalledCount() > 0);
+	t.is(dnsStub.ignored(), 8);
+	t.true(gotStub.called() > 0);
 });
 
-test('IPv4 DNS failure opendns fallbacks to google dns', async t => {
-	ignoreDnsHost(/opendns/);
+test.serial('IPv4 DNS failure opendns fallbacks to google DNS', async t => {
+	dnsStub.ignore(/^208\./);
 	const ip = await publicIp.v4();
 	t.true(isIp.v4(ip));
-	t.true(getIgnoredDnsHosts().length === 4);
-	t.true(getGotCalledCount() === 0);
+	t.is(dnsStub.ignored(), 4);
+	t.is(gotStub.called(), 0);
 });
 
-test('IPv4 HTTPS - No DNS call', async t => {
+test.serial('IPv4 HTTPS - No DNS call', async t => {
 	t.true(isIp.v4(await publicIp.v4({https: true})));
-	t.true(getDnsCalledCount() === 0);
+	t.is(dnsStub.called(), 0);
 });
 
-test('IPv4 HTTPS Disabled - Should only call DNS', async t => {
-	ignoreDnsHost(/.*/);
+test.serial('IPv4 HTTPS Disabled - Should only call DNS', async t => {
+	dnsStub.ignore(/.*/);
 	await t.throwsAsync(publicIp.v4({https: false}));
-	t.true(getDnsCalledCount() > 0);
-	t.true(getGotCalledCount() === 0);
+	t.true(dnsStub.called() > 0);
+	t.is(gotStub.called(), 0);
 });
 
-test('IPv4 HTTPS Uses custom urls', async t => {
-	ignoreGotHosts(/com|org/);
+test.serial('IPv4 HTTPS uses custom URLs', async t => {
+	gotStub.ignore(/com|org/);
 	t.true(isIp.v4(await publicIp.v4({https: true, urls: [
 		'https://ifconfig.co/ip',
 		'https://ifconfig.io/ip'
 	]})));
-	t.true(getIgnoredGotHosts().length === 2);
-	t.true(getDnsCalledCount() === 0);
+	t.is(gotStub.ignored(), 2);
+	t.is(dnsStub.called(), 0);
 });
 
-test('IPv4 DNS timeout', async t => {
+test.serial('IPv4 DNS timeout', async t => {
 	t.true(isIp.v4(await publicIp.v4({timeout: 2000})));
 });
 
-test('IPv4 HTTPS timeout', async t => {
+test.serial('IPv4 HTTPS timeout', async t => {
 	t.true(isIp.v4(await publicIp.v4({https: true, timeout: 4000})));
 });
 
-test('IPv4 DNS cancellation', async t => {
+test.serial('IPv4 DNS cancellation', async t => {
 	const timeout = 5000;
 	const start = process.hrtime();
 	const promise = publicIp.v4({timeout});
@@ -83,7 +73,7 @@ test('IPv4 DNS cancellation', async t => {
 	t.true(milliseconds < timeout);
 });
 
-test('IPv4 HTTPS cancellation', async t => {
+test.serial('IPv4 HTTPS cancellation', async t => {
 	const timeout = 5000;
 	const start = process.hrtime();
 	const promise = publicIp.v4({timeout, https: true});
@@ -97,16 +87,16 @@ test('IPv4 HTTPS cancellation', async t => {
 // Impossible DNS timeouts seems unreliable to test on a working connection
 // because of caches, so we're only testing HTTPS
 
-test('IPv4 HTTPS impossible timeout', async t => {
+test.serial('IPv4 HTTPS impossible timeout', async t => {
 	await t.throwsAsync(publicIp.v4({https: true, timeout: 1}));
 });
 
 if (!process.env.CI) {
-	test('IPv6 DNS', async t => {
+	test.serial('IPv6 DNS', async t => {
 		t.true(isIp.v6(await publicIp.v6()));
 	});
 
-	test('IPv6 HTTPS', async t => {
+	test.serial('IPv6 HTTPS', async t => {
 		t.true(isIp.v6(await publicIp.v6({https: true})));
 	});
 }

--- a/test.js
+++ b/test.js
@@ -69,7 +69,7 @@ test.serial('IPv4 DNS cancellation', async t => {
 test.serial('IPv4 HTTPS cancellation', async t => {
 	const timeout = 5000;
 	const start = process.hrtime();
-	const promise = publicIp.v4({timeout, https: true});
+	const promise = publicIp.v4({timeout, onlyHttps: true});
 	promise.cancel();
 	await promise;
 	const difference = process.hrtime(start);

--- a/test.js
+++ b/test.js
@@ -16,7 +16,7 @@ test.serial('IPv4 DNS - No HTTPS call', async t => {
 	t.is(gotStub.called(), 0);
 });
 
-test.serial('IPv4 DNS failure fallbacks to HTTPS', async t => {
+test.serial('IPv4 DNS failure falls back to HTTPS', async t => {
 	dnsStub.ignore(/.*/);
 	const ip = await publicIp.v4();
 	t.true(isIp.v4(ip));
@@ -24,7 +24,7 @@ test.serial('IPv4 DNS failure fallbacks to HTTPS', async t => {
 	t.true(gotStub.called() > 0);
 });
 
-test.serial('IPv4 DNS failure opendns fallbacks to google DNS', async t => {
+test.serial('IPv4 DNS failure OpenDNS falls back to Google DNS', async t => {
 	dnsStub.ignore(/^208\./);
 	const ip = await publicIp.v4();
 	t.true(isIp.v4(ip));
@@ -33,20 +33,13 @@ test.serial('IPv4 DNS failure opendns fallbacks to google DNS', async t => {
 });
 
 test.serial('IPv4 HTTPS - No DNS call', async t => {
-	t.true(isIp.v4(await publicIp.v4({https: true})));
+	t.true(isIp.v4(await publicIp.v4({onlyHttps: true})));
 	t.is(dnsStub.called(), 0);
-});
-
-test.serial('IPv4 HTTPS Disabled - Should only call DNS', async t => {
-	dnsStub.ignore(/.*/);
-	await t.throwsAsync(publicIp.v4({https: false}));
-	t.true(dnsStub.called() > 0);
-	t.is(gotStub.called(), 0);
 });
 
 test.serial('IPv4 HTTPS uses custom URLs', async t => {
 	gotStub.ignore(/com|org/);
-	t.true(isIp.v4(await publicIp.v4({https: true, urls: [
+	t.true(isIp.v4(await publicIp.v4({onlyHttps: true, fallbackUrls: [
 		'https://ifconfig.co/ip',
 		'https://ifconfig.io/ip'
 	]})));
@@ -59,7 +52,7 @@ test.serial('IPv4 DNS timeout', async t => {
 });
 
 test.serial('IPv4 HTTPS timeout', async t => {
-	t.true(isIp.v4(await publicIp.v4({https: true, timeout: 4000})));
+	t.true(isIp.v4(await publicIp.v4({onlyHttps: true, timeout: 4000})));
 });
 
 test.serial('IPv4 DNS cancellation', async t => {
@@ -88,7 +81,7 @@ test.serial('IPv4 HTTPS cancellation', async t => {
 // because of caches, so we're only testing HTTPS
 
 test.serial('IPv4 HTTPS impossible timeout', async t => {
-	await t.throwsAsync(publicIp.v4({https: true, timeout: 1}));
+	await t.throwsAsync(publicIp.v4({onlyHttps: true, timeout: 1}));
 });
 
 if (!process.env.CI) {
@@ -97,6 +90,6 @@ if (!process.env.CI) {
 	});
 
 	test.serial('IPv6 HTTPS', async t => {
-		t.true(isIp.v6(await publicIp.v6({https: true})));
+		t.true(isIp.v6(await publicIp.v6({onlyHttps: true})));
 	});
 }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-import test from 'ava';
+import {serial as test} from 'ava';
 import isIp from 'is-ip';
 import dnsStub from './mocks/dns-socket';
 import gotStub from './mocks/got';
@@ -9,14 +9,14 @@ test.afterEach.always(() => {
 	gotStub.restore();
 });
 
-test.serial('IPv4 DNS - No HTTPS call', async t => {
+test('IPv4 DNS - No HTTPS call', async t => {
 	t.true(isIp.v4(await publicIp.v4()));
 	t.true(dnsStub.called() > 0);
 	t.is(dnsStub.ignored(), 0);
 	t.is(gotStub.called(), 0);
 });
 
-test.serial('IPv4 DNS failure falls back to HTTPS', async t => {
+test('IPv4 DNS failure falls back to HTTPS', async t => {
 	dnsStub.ignore(/.*/);
 	const ip = await publicIp.v4();
 	t.true(isIp.v4(ip));
@@ -24,7 +24,7 @@ test.serial('IPv4 DNS failure falls back to HTTPS', async t => {
 	t.true(gotStub.called() > 0);
 });
 
-test.serial('IPv4 DNS failure OpenDNS falls back to Google DNS', async t => {
+test('IPv4 DNS failure OpenDNS falls back to Google DNS', async t => {
 	dnsStub.ignore(/^208\./);
 	const ip = await publicIp.v4();
 	t.true(isIp.v4(ip));
@@ -32,12 +32,12 @@ test.serial('IPv4 DNS failure OpenDNS falls back to Google DNS', async t => {
 	t.is(gotStub.called(), 0);
 });
 
-test.serial('IPv4 HTTPS - No DNS call', async t => {
+test('IPv4 HTTPS - No DNS call', async t => {
 	t.true(isIp.v4(await publicIp.v4({onlyHttps: true})));
 	t.is(dnsStub.called(), 0);
 });
 
-test.serial('IPv4 HTTPS uses custom URLs', async t => {
+test('IPv4 HTTPS uses custom URLs', async t => {
 	gotStub.ignore(/com|org/);
 	t.true(isIp.v4(await publicIp.v4({onlyHttps: true, fallbackUrls: [
 		'https://ifconfig.co/ip',
@@ -47,15 +47,15 @@ test.serial('IPv4 HTTPS uses custom URLs', async t => {
 	t.is(dnsStub.called(), 0);
 });
 
-test.serial('IPv4 DNS timeout', async t => {
+test('IPv4 DNS timeout', async t => {
 	t.true(isIp.v4(await publicIp.v4({timeout: 2000})));
 });
 
-test.serial('IPv4 HTTPS timeout', async t => {
+test('IPv4 HTTPS timeout', async t => {
 	t.true(isIp.v4(await publicIp.v4({onlyHttps: true, timeout: 4000})));
 });
 
-test.serial('IPv4 DNS cancellation', async t => {
+test('IPv4 DNS cancellation', async t => {
 	const timeout = 5000;
 	const start = process.hrtime();
 	const promise = publicIp.v4({timeout});
@@ -66,7 +66,7 @@ test.serial('IPv4 DNS cancellation', async t => {
 	t.true(milliseconds < timeout);
 });
 
-test.serial('IPv4 HTTPS cancellation', async t => {
+test('IPv4 HTTPS cancellation', async t => {
 	const timeout = 5000;
 	const start = process.hrtime();
 	const promise = publicIp.v4({timeout, onlyHttps: true});
@@ -80,16 +80,14 @@ test.serial('IPv4 HTTPS cancellation', async t => {
 // Impossible DNS timeouts seems unreliable to test on a working connection
 // because of caches, so we're only testing HTTPS
 
-test.serial('IPv4 HTTPS impossible timeout', async t => {
+test('IPv4 HTTPS impossible timeout', async t => {
 	await t.throwsAsync(publicIp.v4({onlyHttps: true, timeout: 1}));
 });
 
-if (!process.env.CI) {
-	test.serial('IPv6 DNS', async t => {
-		t.true(isIp.v6(await publicIp.v6()));
-	});
+test('IPv6 DNS', async t => {
+	t.true(isIp.v6(await publicIp.v6()));
+});
 
-	test.serial('IPv6 HTTPS', async t => {
-		t.true(isIp.v6(await publicIp.v6({onlyHttps: true})));
-	});
-}
+test('IPv6 HTTPS', async t => {
+	t.true(isIp.v6(await publicIp.v6({onlyHttps: true})));
+});


### PR DESCRIPTION
Some things that could be considered to be useful:
* Multiple DNS resolver host alternatives
* Multiple DNS resolver providers
* Fallback to HTTPS by default if DNS does not resolve (no need to choose one or the other, just try DNS and if it fails use HTTPS)
* Ability to disable or enable HTTPS check (`{ https: true }` will only check HTTPS). Defaults to DNS + HTTPS
* Added `options.urls` array to be able to add more urls to fallback to (like `ifconfig.co`)