### PR TITLE
fixed edge spread operator issue

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -21,8 +21,8 @@ let xhr;
 const sendXhr = async (url, options, version) => {
 	return new Promise((resolve, reject) => {
 		xhr = new XMLHttpRequest();
-		xhr.addEventListener('error', reject, {once: true});
-		xhr.addEventListener('timeout', reject, {once: true});
+		xhr.addEventListener('error', reject, { once: true });
+		xhr.addEventListener('timeout', reject, { once: true });
 
 		xhr.addEventListener('load', () => {
 			const ip = xhr.responseText.trim();
@@ -33,7 +33,7 @@ const sendXhr = async (url, options, version) => {
 			}
 
 			resolve(ip);
-		}, {once: true});
+		}, { once: true });
 
 		xhr.open('GET', url);
 		xhr.timeout = options.timeout;
@@ -49,7 +49,7 @@ const queryHttps = async (version, options) => {
 			// eslint-disable-next-line no-await-in-loop
 			ip = await sendXhr(url, options, version);
 			return ip;
-		} catch (_) {}
+		} catch (_) { }
 	}
 
 	throw new Error('Couldn\'t find your IP');
@@ -59,6 +59,6 @@ queryHttps.cancel = () => {
 	xhr.abort();
 };
 
-module.exports.v4 = options => queryHttps('v4', {...defaults, ...options});
+module.exports.v4 = options => queryHttps('v4', Object.assign({}, defaults, options));
 
-module.exports.v6 = options => queryHttps('v6', {...defaults, ...options});
+module.exports.v6 = options => queryHttps('v6', Object.assign({}, defaults, options));

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
-const {promisify} = require('util');
+const { promisify } = require('util');
 const dgram = require('dgram');
 const dns = require('dns-socket');
-const {get: got, CancelError} = require('got');
+const { get: got, CancelError } = require('got');
 const isIp = require('is-ip');
 
 const defaults = {
@@ -59,7 +59,7 @@ const dnsServers = [
 
 const type = {
 	v4: {
-		dnsServers: dnsServers.map(({v4: {servers, ...question}}) => ({
+		dnsServers: dnsServers.map(({ v4: { servers, ...question } }) => ({
 			servers, question
 		})),
 		httpsUrls: [
@@ -68,7 +68,7 @@ const type = {
 		]
 	},
 	v6: {
-		dnsServers: dnsServers.map(({v6: {servers, ...question}}) => ({
+		dnsServers: dnsServers.map(({ v6: { servers, ...question } }) => ({
 			servers, question
 		})),
 		httpsUrls: [
@@ -91,13 +91,13 @@ const queryDns = (version, options) => {
 
 	const promise = (async () => {
 		for (const dnsServerInfo of data.dnsServers) {
-			const {servers, question} = dnsServerInfo;
+			const { servers, question } = dnsServerInfo;
 			for (const server of servers) {
 				try {
-					const {name, type, transform} = question;
+					const { name, type, transform } = question;
 
 					// eslint-disable-next-line no-await-in-loop
-					const dnsResponse = await socketQuery({questions: [{name, type}]}, 53, server);
+					const dnsResponse = await socketQuery({ questions: [{ name, type }] }, 53, server);
 
 					const {
 						answers: {
@@ -115,7 +115,7 @@ const queryDns = (version, options) => {
 						socket.destroy();
 						return ip;
 					}
-				} catch (_) {}
+				} catch (_) { }
 			}
 		}
 
@@ -203,10 +203,7 @@ const queryAll = (version, options) => {
 };
 
 module.exports.v4 = options => {
-	options = {
-		...defaults,
-		...options
-	};
+	options = Object.assign({}, defaults, options);
 
 	if (!options.onlyHttps) {
 		return queryAll('v4', options);
@@ -220,10 +217,7 @@ module.exports.v4 = options => {
 };
 
 module.exports.v6 = options => {
-	options = {
-		...defaults,
-		...options
-	};
+	options = Object.assign({}, defaults, options);
 
 	if (!options.onlyHttps) {
 		return queryAll('v6', options);


### PR DESCRIPTION
Changed { ...defaults, ...options } to Object.assign({}...) syntax, because Edge breaks over spread operator (not supported in ES5) when it is included in eg. Angular project.