### PR TITLE
Add new API URLs

### DIFF
--- a/api-urls-regex.js
+++ b/api-urls-regex.js
@@ -1,0 +1,9 @@
+// URL and regex which matches the IP in the response.
+// These URLs accept both IPv6/IPv4 connectivity
+// Response might change for dual IPv6/IPv4 stack network interface
+const regexUrls = {
+	'https://www.cloudflare.com/cdn-cgi/trace': /ip=(?<ip>.*)/,
+	'https://ip-api.io/api/json': /ip"(.*?)"(?<ip>.*?)"/
+};
+
+module.exports = regexUrls;

--- a/browser.js
+++ b/browser.js
@@ -47,9 +47,9 @@ const sendXhr = async (url, options, version) => {
 };
 
 const queryHttps = async (version, options) => {
-	let ip;
 	const urls_ = [].concat.apply(urls[version], options.fallbackUrls || []);
 	for (const url of urls_) {
+		let ip;
 		try {
 			// eslint-disable-next-line no-await-in-loop
 			ip = await sendXhr(url, options, version);

--- a/browser.js
+++ b/browser.js
@@ -65,15 +65,14 @@ queryHttps.cancel = () => {
 };
 
 const v6or4 = async options => {
-	let ip;
 	const fallbackUrls = options.fallbackUrls || {};
 	const urls_ = {...urls.v6or4, ...fallbackUrls};
 
 	for (const url of Object.keys(urls_)) {
 		try {
 			// eslint-disable-next-line no-await-in-loop
-			ip = await sendXhr(url, options);
-			ip = ip.match(urls_[url])[2]
+			let ip = await sendXhr(url, options);
+			ip = ip.match(urls_[url])[2];
 			if (ip && (isIp.v4(ip) || isIp.v6(ip))) {
 				return ip;
 			}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava test.js && tsd"
+		"test-browser": "airtap --local test-browser.js",
+		"test-node": "xo && ava test.js && tsd",
+		"test": "npm run test-node && npm run test-browser"
 	},
 	"files": [
 		"index.js",
@@ -40,8 +42,10 @@
 		"is-ip": "^3.1.0"
 	},
 	"devDependencies": {
+		"airtap": "^3.0.0",
 		"ava": "^2.2.0",
 		"sinon": "^7.4.1",
+		"tape": "^5.0.1",
 		"tsd": "^0.11.0",
 		"xo": "^0.25.3"
 	},

--- a/test-browser.js
+++ b/test-browser.js
@@ -4,7 +4,7 @@
 const publicIp = require('./browser');
 const test = require('tape');
 
-let v6Address = false;
+let v6Address = null;
 
 test('v6', async t => {
 	publicIp.v6().then(async ip1 => {
@@ -14,7 +14,7 @@ test('v6', async t => {
 		t.end();
 	}).catch(error => {
 		if (error === 'Couldn\'t find your IP') {
-			v6Address = false;
+			v6Address = null;
 		}
 
 		t.end();
@@ -37,7 +37,7 @@ test('v6or4', async t => {
 	publicIp.v6or4().then(async ip1 => {
 		const ip2 = await publicIp.v4();
 
-		if (v6Address === false) {
+		if (!v6Address) {
 			t.equal(ip1, ip2);
 		} else {
 			t.equal(ip1, v6Address);

--- a/test-browser.js
+++ b/test-browser.js
@@ -7,42 +7,28 @@ const test = require('tape');
 let v6Address = null;
 
 test('v6', async t => {
-	publicIp.v6().then(async ip1 => {
+	try {
+		const ip1 = await publicIp.v6();
 		v6Address = await publicIp.v6();
 
 		t.equal(ip1, v6Address);
 		t.end();
-	}).catch(error => {
+	} catch (error) {
 		if (error === 'Couldn\'t find your IP') {
 			v6Address = null;
 		}
 
 		t.end();
-	});
+	}
 });
 
 test('v4', async t => {
-	publicIp.v4().then(async ip1 => {
-		const ip2 = await publicIp.v4({
-			fallbackUrls: [
-				'https://ifconfig.me'
-			]
-		});
-		t.equal(ip1, ip2);
-		t.end();
+	const ip1 = await publicIp.v4();
+	const ip2 = await publicIp.v4({
+		fallbackUrls: [
+			'https://ifconfig.me'
+		]
 	});
-});
-
-test('v6or4', async t => {
-	publicIp.v6or4().then(async ip1 => {
-		const ip2 = await publicIp.v4();
-
-		if (!v6Address) {
-			t.equal(ip1, ip2);
-		} else {
-			t.equal(ip1, v6Address);
-		}
-
-		t.end();
-	});
+	t.equal(ip1, ip2);
+	t.end();
 });

--- a/test-browser.js
+++ b/test-browser.js
@@ -4,31 +4,32 @@
 const publicIp = require('./browser');
 const test = require('tape');
 
-let v6Address = null;
-
 test('v6', async t => {
 	try {
 		const ip1 = await publicIp.v6();
-		v6Address = await publicIp.v6();
+		const ip2 = await publicIp.v6();
 
-		t.equal(ip1, v6Address);
+		console.log(ip1);
+		t.equal(ip1, ip2);
 		t.end();
 	} catch (error) {
-		if (error === 'Couldn\'t find your IP') {
-			v6Address = null;
-		}
-
-		t.end();
+		t.end(error);
 	}
 });
 
 test('v4', async t => {
-	const ip1 = await publicIp.v4();
-	const ip2 = await publicIp.v4({
-		fallbackUrls: [
-			'https://ifconfig.me'
-		]
-	});
-	t.equal(ip1, ip2);
-	t.end();
+	try {
+		const ip1 = await publicIp.v4();
+		const ip2 = await publicIp.v4({
+			fallbackUrls: [
+				'https://ifconfig.me'
+			]
+		});
+
+		console.log(ip1);
+		t.equal(ip1, ip2);
+		t.end();
+	} catch (error) {
+		t.end(error);
+	}
 });

--- a/test-browser.js
+++ b/test-browser.js
@@ -2,13 +2,22 @@
 // $ browserify test-browser.js | pbcopy
 'use strict';
 const publicIp = require('./browser');
+const test = require('tape');
 
-(async () => {
-	console.log('IP:', await publicIp.v4());
-	console.log('IP:', await publicIp.v4({
+test('ipv4', async t => {
+	const ip1 = await publicIp.v4();
+	const ip2 = await publicIp.v4({
 		fallbackUrls: [
 			'https://ifconfig.me'
 		]
-	}));
-	console.log('IP:', await publicIp.v6or4());
-})();
+	});
+	t.equal(ip1, ip2);
+	t.end();
+});
+
+test('ipv6', async t => {
+	const ip1 = await publicIp.v6();
+	const ip2 = await publicIp.v6();
+	t.equal(ip1, ip2);
+	t.end();
+});

--- a/test-browser.js
+++ b/test-browser.js
@@ -10,4 +10,5 @@ const publicIp = require('./browser');
 			'https://ifconfig.me'
 		]
 	}));
+	console.log('IP:', await publicIp.v6or4());
 })();

--- a/test-browser.js
+++ b/test-browser.js
@@ -12,17 +12,17 @@ test('v6', async t => {
 
 		t.equal(ip1, v6Address);
 		t.end();
-	}).catch(err => {
-		if (err === 'Couldn\'t find your IP') {
+	}).catch(error => {
+		if (error === 'Couldn\'t find your IP') {
 			v6Address = false;
 		}
+
 		t.end();
 	});
 });
 
 test('v4', async t => {
 	publicIp.v4().then(async ip1 => {
-		console.log(ip1)
 		const ip2 = await publicIp.v4({
 			fallbackUrls: [
 				'https://ifconfig.me'
@@ -37,12 +37,12 @@ test('v6or4', async t => {
 	publicIp.v6or4().then(async ip1 => {
 		const ip2 = await publicIp.v4();
 
-		if (v6Address !== false) {
-			t.equal(ip1, v6Address);
-		} else {
+		if (v6Address === false) {
 			t.equal(ip1, ip2);
+		} else {
+			t.equal(ip1, v6Address);
 		}
-	
+
 		t.end();
 	});
 });

--- a/test-browser.js
+++ b/test-browser.js
@@ -4,20 +4,45 @@
 const publicIp = require('./browser');
 const test = require('tape');
 
-test('ipv4', async t => {
-	const ip1 = await publicIp.v4();
-	const ip2 = await publicIp.v4({
-		fallbackUrls: [
-			'https://ifconfig.me'
-		]
+let v6Address = false;
+
+test('v6', async t => {
+	publicIp.v6().then(async ip1 => {
+		v6Address = await publicIp.v6();
+
+		t.equal(ip1, v6Address);
+		t.end();
+	}).catch(err => {
+		if (err === 'Couldn\'t find your IP') {
+			v6Address = false;
+		}
+		t.end();
 	});
-	t.equal(ip1, ip2);
-	t.end();
 });
 
-test('ipv6', async t => {
-	const ip1 = await publicIp.v6();
-	const ip2 = await publicIp.v6();
-	t.equal(ip1, ip2);
-	t.end();
+test('v4', async t => {
+	publicIp.v4().then(async ip1 => {
+		console.log(ip1)
+		const ip2 = await publicIp.v4({
+			fallbackUrls: [
+				'https://ifconfig.me'
+			]
+		});
+		t.equal(ip1, ip2);
+		t.end();
+	});
+});
+
+test('v6or4', async t => {
+	publicIp.v6or4().then(async ip1 => {
+		const ip2 = await publicIp.v4();
+
+		if (v6Address !== false) {
+			t.equal(ip1, v6Address);
+		} else {
+			t.equal(ip1, ip2);
+		}
+	
+		t.end();
+	});
 });


### PR DESCRIPTION
Fixes #45 
Added new general HTTPs APIs from which IP is retrieved with a regex pattern. Adds a JSON object to do that :
```
general: {
  'https://www.cloudflare.com/cdn-cgi/trace': 'ip(=)(.*?)\n',
  'https://ip-api.io/api/json': 'ip"(.*?)"(.*?)"'
}
```