### PR TITLE
Remove now unneeded temp fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,6 @@ const queryDns = (version, options) => {
 		socket: dgram.createSocket(version === 'v6' ? 'udp6' : 'udp4'),
 		timeout: options.timeout
 	});
-	socket.retries = 0; // Temp fix, pull request: https://github.com/mafintosh/dns-socket/pull/22
 
 	const socketQuery = promisify(socket.query.bind(socket));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "public-ip",
-	"version": "4.0.1",
+	"version": "4.0.2",
 	"description": "Get your public IP address - very fast!",
 	"license": "MIT",
 	"repository": "sindresorhus/public-ip",
@@ -35,7 +35,7 @@
 		"dns"
 	],
 	"dependencies": {
-		"dns-socket": "^4.2.0",
+		"dns-socket": "^4.2.1",
 		"got": "^9.6.0",
 		"is-ip": "^3.1.0"
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "public-ip",
-	"version": "4.0.2",
+	"version": "4.0.1",
 	"description": "Get your public IP address - very fast!",
 	"license": "MIT",
 	"repository": "sindresorhus/public-ip",


### PR DESCRIPTION
This PR removes a single line which is not needed with the updated dependency.

### scope
- introduces in #42
- fixed via https://github.com/mafintosh/dns-socket/pull/22