### PR TITLE
Fix problem with calling the browser version concurrently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 yarn.lock
-.vscode

--- a/browser.js
+++ b/browser.js
@@ -16,11 +16,9 @@ const urls = {
 	]
 };
 
-let xhr;
-
 const sendXhr = async (url, options, version) => {
 	return new Promise((resolve, reject) => {
-		xhr = new XMLHttpRequest();
+		const xhr = new XMLHttpRequest();
 		xhr.addEventListener('error', reject, {once: true});
 		xhr.addEventListener('timeout', reject, {once: true});
 
@@ -53,10 +51,6 @@ const queryHttps = async (version, options) => {
 	}
 
 	throw new Error('Couldn\'t find your IP');
-};
-
-queryHttps.cancel = () => {
-	xhr.abort();
 };
 
 module.exports.v4 = options => queryHttps('v4', {...defaults, ...options});

--- a/browser.js
+++ b/browser.js
@@ -3,9 +3,9 @@ const isIp = require('is-ip');
 
 const defaults = {
 	timeout: 5000
-  };
+};
 
-  const urls = {
+const urls = {
 	v4: [
 		'https://ipv4.icanhazip.com/',
 		'https://api.ipify.org/'
@@ -16,55 +16,58 @@ const defaults = {
 	]
 };
 
-  const sendXhr = (url, options, version) => {
+const sendXhr = (url, options, version) => {
 	const xhr = new XMLHttpRequest();
 	let _resolve;
 	const promise = new Promise((resolve, reject) => {
-	  _resolve = resolve;
-	  xhr.addEventListener('error', reject, { once: true });
-	  xhr.addEventListener('timeout', reject, { once: true });
+		_resolve = resolve;
+		xhr.addEventListener('error', reject, {once: true});
+		xhr.addEventListener('timeout', reject, {once: true});
 
-	  xhr.addEventListener('load', () => {
-		  const ip = xhr.responseText.trim();
+		xhr.addEventListener('load', () => {
+			const ip = xhr.responseText.trim();
 
-		  if (!ip || !isIp[version](ip)) {
-			reject();
-			return;
-		  }
+			if (!ip || !isIp[version](ip)) {
+				reject();
+				return;
+			}
 
-		  resolve(ip);
+			resolve(ip);
 		}, {once: true});
 
-	  xhr.open('GET', url);
-	  xhr.timeout = options.timeout;
-	  xhr.send();
+		xhr.open('GET', url);
+		xhr.timeout = options.timeout;
+		xhr.send();
 	});
 	promise.cancel = () => {
-	  _resolve();
-	  xhr.abort();
-	}
-	return promise;
-  };
+		_resolve();
+		xhr.abort();
+	};
 
-  const queryHttps = (version, options) => {
+	return promise;
+};
+
+const queryHttps = (version, options) => {
 	let request;
 	const promise = (async function () {
-	  const urls_ = [].concat.apply(urls[version], options.fallbackUrls || []);
-	  for (const url of urls_) {
-		try {
-		  // eslint-disable-next-line no-await-in-loop
-		  request = sendXhr(url, options, version);
-		  const ip = await request;
-		  return ip;
-		} catch (_) {}
-	  }
-	  throw new Error("Couldn't find your IP");
+		const urls_ = [].concat.apply(urls[version], options.fallbackUrls || []);
+		for (const url of urls_) {
+			try {
+				request = sendXhr(url, options, version);
+				// eslint-disable-next-line no-await-in-loop
+				const ip = await request;
+				return ip;
+			} catch (_) {}
+		}
+
+		throw new Error('Couldn\'t find your IP');
 	})();
 	promise.cancel = () => {
-	  request.cancel();
+		request.cancel();
 	};
+
 	return promise;
-  };
+};
 
 module.exports.v4 = options => queryHttps('v4', {...defaults, ...options});
 

--- a/browser.js
+++ b/browser.js
@@ -59,9 +59,9 @@ const queryHttps = (version, options) => {
 				// eslint-disable-next-line no-await-in-loop
 				const ip = await request;
 				return ip;
-			} catch (e) {
-				if(e instanceof CancelError) {
-					throw e;
+			} catch (error) {
+				if (error instanceof CancelError) {
+					throw error;
 				}
 			}
 		}
@@ -78,8 +78,8 @@ const queryHttps = (version, options) => {
 
 class CancelError extends Error {
 	constructor() {
-		super("Request was cancelled");
-		this.name = "CancelError";
+		super('Request was cancelled');
+		this.name = 'CancelError';
 	}
 
 	get isCanceled() {

--- a/browser.js
+++ b/browser.js
@@ -1,6 +1,17 @@
 'use strict';
 const isIp = require('is-ip');
 
+class CancelError extends Error {
+	constructor() {
+		super('Request was cancelled');
+		this.name = 'CancelError';
+	}
+
+	get isCanceled() {
+		return true;
+	}
+}
+
 const defaults = {
 	timeout: 5000
 };
@@ -75,17 +86,6 @@ const queryHttps = (version, options) => {
 
 	return promise;
 };
-
-class CancelError extends Error {
-	constructor() {
-		super('Request was cancelled');
-		this.name = 'CancelError';
-	}
-
-	get isCanceled() {
-		return true;
-	}
-}
 
 module.exports.v4 = options => queryHttps('v4', {...defaults, ...options});
 

--- a/browser.js
+++ b/browser.js
@@ -40,8 +40,8 @@ const sendXhr = (url, options, version) => {
 		xhr.send();
 	});
 	promise.cancel = () => {
-		_resolve();
 		xhr.abort();
+		_resolve();
 	};
 
 	return promise;

--- a/browser.js
+++ b/browser.js
@@ -3,9 +3,9 @@ const isIp = require('is-ip');
 
 const defaults = {
 	timeout: 5000
-};
+  };
 
-const urls = {
+  const urls = {
 	v4: [
 		'https://ipv4.icanhazip.com/',
 		'https://api.ipify.org/'
@@ -16,42 +16,55 @@ const urls = {
 	]
 };
 
-const sendXhr = async (url, options, version) => {
-	return new Promise((resolve, reject) => {
-		const xhr = new XMLHttpRequest();
-		xhr.addEventListener('error', reject, {once: true});
-		xhr.addEventListener('timeout', reject, {once: true});
+  const sendXhr = (url, options, version) => {
+	const xhr = new XMLHttpRequest();
+	let _resolve;
+	const promise = new Promise((resolve, reject) => {
+	  _resolve = resolve;
+	  xhr.addEventListener('error', reject, { once: true });
+	  xhr.addEventListener('timeout', reject, { once: true });
 
-		xhr.addEventListener('load', () => {
-			const ip = xhr.responseText.trim();
+	  xhr.addEventListener('load', () => {
+		  const ip = xhr.responseText.trim();
 
-			if (!ip || !isIp[version](ip)) {
-				reject();
-				return;
-			}
+		  if (!ip || !isIp[version](ip)) {
+			reject();
+			return;
+		  }
 
-			resolve(ip);
+		  resolve(ip);
 		}, {once: true});
 
-		xhr.open('GET', url);
-		xhr.timeout = options.timeout;
-		xhr.send();
+	  xhr.open('GET', url);
+	  xhr.timeout = options.timeout;
+	  xhr.send();
 	});
-};
-
-const queryHttps = async (version, options) => {
-	let ip;
-	const urls_ = [].concat.apply(urls[version], options.fallbackUrls || []);
-	for (const url of urls_) {
-		try {
-			// eslint-disable-next-line no-await-in-loop
-			ip = await sendXhr(url, options, version);
-			return ip;
-		} catch (_) {}
+	promise.cancel = () => {
+	  _resolve();
+	  xhr.abort();
 	}
+	return promise;
+  };
 
-	throw new Error('Couldn\'t find your IP');
-};
+  const queryHttps = (version, options) => {
+	let request;
+	const promise = (async function () {
+	  const urls_ = [].concat.apply(urls[version], options.fallbackUrls || []);
+	  for (const url of urls_) {
+		try {
+		  // eslint-disable-next-line no-await-in-loop
+		  request = sendXhr(url, options, version);
+		  const ip = await request;
+		  return ip;
+		} catch (_) {}
+	  }
+	  throw new Error("Couldn't find your IP");
+	})();
+	promise.cancel = () => {
+	  request.cancel();
+	};
+	return promise;
+  };
 
 module.exports.v4 = options => queryHttps('v4', {...defaults, ...options});
 

--- a/browser.js
+++ b/browser.js
@@ -18,6 +18,7 @@ const urls = {
 
 const sendXhr = (url, options, version) => {
 	const xhr = new XMLHttpRequest();
+
 	let _resolve;
 	const promise = new Promise((resolve, reject) => {
 		_resolve = resolve;
@@ -39,6 +40,7 @@ const sendXhr = (url, options, version) => {
 		xhr.timeout = options.timeout;
 		xhr.send();
 	});
+
 	promise.cancel = () => {
 		xhr.abort();
 		_resolve();
@@ -62,6 +64,7 @@ const queryHttps = (version, options) => {
 
 		throw new Error('Couldn\'t find your IP');
 	})();
+
 	promise.cancel = () => {
 		request.cancel();
 	};


### PR DESCRIPTION
- Uses closure on xhr to avoid referencing the wrong xhr object in the `load` callback if multiple requests are done in parallel
- Remove the abort method that was not exported so was useless

Closes #52 