### PR TITLE
Bump dns-socket from ^4.2.1 to ^4.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"dns"
 	],
 	"dependencies": {
-		"dns-socket": "^4.2.1",
+		"dns-socket": "^4.2.2",
 		"got": "^9.6.0",
 		"is-ip": "^3.1.0"
 	},


### PR DESCRIPTION
Address vulnerability [CVE-2021-23386](https://nvd.nist.gov/vuln/detail/CVE-2021-23386).
All tests pass.