### PR TITLE
Don't throw CancelError if ipv6 resolves first

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
         node-version:
           - 18
           - 16
-          - 14
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/core.js
+++ b/core.js
@@ -15,7 +15,7 @@ export function createPublicIp(publicIpv4, publicIpv6) {
 		const promise = (async () => {
 			try {
 				const ipv6 = await ipv6Promise;
-				ipv4Promise.catch(() => {});
+				ipv4Promise.catch(() => {}); // Don't throw when cancelling
 				ipv4Promise.cancel();
 				return ipv6;
 			} catch (ipv6Error) {

--- a/core.js
+++ b/core.js
@@ -15,7 +15,7 @@ export function createPublicIp(publicIpv4, publicIpv6) {
 		const promise = (async () => {
 			try {
 				const ipv6 = await ipv6Promise;
-				ipv4Promise.cancel();
+				ipv4Promise.catch(() => {}).cancel();
 				return ipv6;
 			} catch (ipv6Error) {
 				if (!(ipv6Error instanceof IpNotFoundError)) {

--- a/core.js
+++ b/core.js
@@ -15,7 +15,8 @@ export function createPublicIp(publicIpv4, publicIpv6) {
 		const promise = (async () => {
 			try {
 				const ipv6 = await ipv6Promise;
-				ipv4Promise.catch(() => {}).cancel();
+				ipv4Promise.catch(() => {});
+				ipv4Promise.cancel();
 				return ipv6;
 			} catch (ipv6Error) {
 				if (!(ipv6Error instanceof IpNotFoundError)) {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 	},
 	"devDependencies": {
 		"ava": "^4.3.0",
+		"esmock": "^2.6.4",
 		"sinon": "^14.0.0",
 		"time-span": "^5.0.0",
 		"tsd": "^0.21.0",
@@ -64,6 +65,9 @@
 		"serial": true,
 		"files": [
 			"test.js"
+		],
+		"nodeArguments": [
+			"--loader=esmock"
 		]
 	}
 }


### PR DESCRIPTION
Fixes #69 