### PR TITLE
 docs: add reliable C-based API to fallbackUrls example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,7 @@ import {publicIpv6} from 'public-ip';
 
 await publicIpv6({
 	fallbackUrls: [
+		'https://mioip.info',
 		'https://ifconfig.co/ip'
 	]
 });


### PR DESCRIPTION
Hi @sindresorhus!
Just a quick doc update. Added https://mioip.info to the fallbackUrls example in the readme.
I built it as a free, sub-millisecond wrapper in pure C over the local MaxMind .mmdb. It has zero rate limits, no auth, and supports both IPv4 and IPv6 out of the box.
Since ifconfig.co sometimes throws 429 Too Many Requests in CI/CD environments, having a no-limit alternative in the docs examples can be super helpful for developers relying on the fallback mechanism.
Thanks for the amazing package!